### PR TITLE
Mobile layout fixes

### DIFF
--- a/public/mobile_layout_test.html
+++ b/public/mobile_layout_test.html
@@ -1,0 +1,132 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <style>
+
+    :root {
+      --bar-height: 70px; /* If you change this you must change the max aspect ratio below */
+      --video-padding: 10px;
+      --viewport-height: 100vh; /* Fallback before javascript kicks in */
+    }
+
+    html, body {
+      margin: 0;
+      padding: 0;
+      overscroll-behavior-y: contain; /* Chrome only */
+    }
+
+    body {
+      font-family: sans-serif;
+      font-size: 14px;
+    }
+
+    .bar {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      height: var(--bar-height);
+    }
+
+    .bar--top {
+      background-color: gray;
+    }
+
+    .bar--bottom {
+      background-color: gray;
+      position: absolute;
+      bottom: 0;
+      left: 0;
+    }
+
+    .video_container {
+      transform: rotate(90deg);
+      transform-origin: 50vw;
+      height: 100vw;
+      width: calc(var(--viewport-height) - (var(--bar-height) * 2));
+      background-color: aqua;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      position: relative;
+    }
+
+
+    .video_rotated {
+      --video-wide-screen-width: var(--viewport-height) - (var(--bar-height) * 2) - (var(--video-padding) * 2);
+      position: relative;
+      width: 100%;
+      background-color: pink;
+      overflow: hidden;
+
+      width: calc(var(--video-wide-screen-width));
+      max-width: calc(var(--video-wide-screen-width));
+      padding-top: calc((var(--video-wide-screen-width)) * .75);
+      /*
+      padding-top: 10%;
+      */
+    }
+
+    /* Aspect ratio width to height */
+    /* If the info bars are 100px tall, the video logic will shift at 300px wide and 600px tall */
+    /* If the bars are 70px tall, the video logic will shift at 360px wide and 600px tall */
+    /* Etc... */
+    @media (max-aspect-ratio: 360/600) {
+      .video_rotated {
+        --video-tall-screen-width: 100vw - (var(--video-padding) * 2);
+        background-color: gold;
+        max-width: calc((var(--video-tall-screen-width)) * 1.33);
+        padding-top: calc(var(--video-tall-screen-width));
+      }
+    }
+
+    .video_iframe {
+      position: absolute;
+      top: 0;
+      left: 0;
+      top: -20%;
+    }
+
+    .button {
+      width: 30px;
+      height: 30px;
+      border: 1px solid #000;
+      flex-shrink: 0;
+    }
+  </style>
+
+</head>
+<body>
+  <div class="app">
+    <div class="bar bar--top">
+      <div class="button button--left">&larr;</div>
+      <h4>You're watching Colored TV by Def Sound. You're watching Colored TV by Def Sound. You're watching Colored TV by Def Sound. You're watching Colored TV by Def Sound. You're watching Colored TV by Def Sound. You're watching Colored TV by Def Sound. You're watching Colored TV by Def Sound. You're watching Colored TV by Def Sound</h4>
+      <div class="button button--right">&sung;</div>
+    </div>
+    <div class="video_container">
+        <div class="video_rotated">
+          <iframe class="video_iframe" frameborder="0" allowfullscreen="1" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" title="YouTube video player" width="100%" height="140%" src="https://www.youtube.com/embed/gSfVVXql-I4?autoplay=1&mute=1&controls=0&origin=http%3A%2F%2Flocalhost%3A3000&playsinline=1&showinfo=0&rel=0&iv_load_policy=3&modestbranding=1&enablejsapi=1&widgetid=1" id="widget4"></iframe>
+        </div>
+    </div>
+    <div class="bar bar--bottom">
+      <div class="button button--bottom">&rarr;</div>
+      <h4>Now playing: Black, Blues, Black! with Maya Angelou</h4>
+    </div>
+  </div>
+
+
+  <script>
+    document.addEventListener("DOMContentLoaded", function(){
+      // First we get the viewport height (the full height since we're only using "100vh" currently)
+      let vh = window.innerHeight;
+      // Then we set the value in the --vh custom property to the root of the document
+      document.documentElement.style.setProperty('--viewport-height', `${vh}px`);
+    });
+
+    window.addEventListener('resize', () => {
+      // We execute the same script as before
+      let vh = window.innerHeight;
+      document.documentElement.style.setProperty('--viewport-height', `${vh}px`);
+    });
+  </script>
+</body>
+</html>

--- a/src/AppContents.js
+++ b/src/AppContents.js
@@ -17,7 +17,7 @@ import Tooltip from './Tooltip';
 
 import styled from '@emotion/styled';
 
-import { Logo } from './styles';
+import { Logo, mobileViewportHeight } from './styles';
 
 const LoadingContainer = styled('div')`
   display: flex;
@@ -25,13 +25,13 @@ const LoadingContainer = styled('div')`
   justify-content: center;
   flex-direction: column;
   text-align: center;
-  height: 100vh;
+  height: 100vh; // TODO: Could replace this on mobile if it becomes a scroll problem
   width: 100vw;
 `;
 
 const MobileSupportOverlay = styled('div')`
   width: 100vw;
-  height: 100vh;
+  height: ${mobileViewportHeight};
   position: absolute;
   top: 0;
   left: 0;

--- a/src/MobileProgram.js
+++ b/src/MobileProgram.js
@@ -45,7 +45,6 @@ class MobileProgram extends Component {
               video={this.props.currentProgramBlock.currentVideo}
               timestamp={this.props.currentProgramBlock.timestampToStartVideo}
               className={mobileVideo}
-              cropControls={true}
               isMobile={true}
             />
           }

--- a/src/MobileProgram.js
+++ b/src/MobileProgram.js
@@ -22,11 +22,6 @@ class MobileProgram extends Component {
         <MobileProgramContainer>
           { this.props.currentProgramBlock &&
             <React.Fragment>
-              <Video
-                video={this.props.currentProgramBlock.currentVideo}
-                timestamp={this.props.currentProgramBlock.timestampToStartVideo}
-                className={mobileVideo}
-              />
               { !this.props.showMobileProgramInfo &&
                 <div className={mobileTopRightIcon}><MuteButton /></div>
               }
@@ -42,6 +37,17 @@ class MobileProgram extends Component {
                 <div className={mobileNextChannel}><ChannelButton direction="next" to={this.props.nextChannelSlug} /></div>
               }
             </React.Fragment>
+          }
+        </MobileProgramContainer>
+        <MobileProgramContainer className={videoContainer}>
+          { this.props.currentProgramBlock &&
+            <Video
+              video={this.props.currentProgramBlock.currentVideo}
+              timestamp={this.props.currentProgramBlock.timestampToStartVideo}
+              className={mobileVideo}
+              cropControls={true}
+              isMobile={true}
+            />
           }
           { (!this.props.currentProgramBlock || !this.props.currentProgramBlock.fields.videos) &&
             <VideoPlaceholderWrapper className={mobileVideo} />
@@ -94,10 +100,14 @@ const MobileProgramContainer = styled('div')`
   transform-origin: 50vw;
   width: ${mobileViewportHeight};
   height: 100vw;
-  position: relative;
+  position: absolute;
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+const videoContainer = css`
+  z-index: -1; // Necessary because of the transform
 `;
 
 const mobileVideoWidth = '90vw * 1.33';

--- a/src/MobileProgram.js
+++ b/src/MobileProgram.js
@@ -116,7 +116,6 @@ const mobileInfoContainerHeight = `calc((${mobileVideoWidth}) + ${mobileTextHeig
 
 const mobileVideo = css`
   width: calc(${mobileVideoWidth});
-  padding-top: 50%;
 `;
 
 const mobileTopRightIcon = css`

--- a/src/MobileProgram.js
+++ b/src/MobileProgram.js
@@ -45,7 +45,7 @@ class MobileProgram extends Component {
             </React.Fragment>
           }
           { (!this.props.currentProgramBlock || !this.props.currentProgramBlock.fields.videos) &&
-            <VideoPlaceholderWrapper className={mobileVideo} />
+            <VideoPlaceholderWrapper className={mobileVideo} isMobile={true} />
           }
         </MobileProgramContainer>
         <TopMobileText>

--- a/src/MobileProgram.js
+++ b/src/MobileProgram.js
@@ -22,6 +22,12 @@ class MobileProgram extends Component {
         <MobileProgramContainer>
           { this.props.currentProgramBlock &&
             <React.Fragment>
+              <Video
+                video={this.props.currentProgramBlock.currentVideo}
+                timestamp={this.props.currentProgramBlock.timestampToStartVideo}
+                className={mobileVideo}
+                isMobile={true}
+              />
               { !this.props.showMobileProgramInfo &&
                 <div className={mobileTopRightIcon}><MuteButton /></div>
               }
@@ -37,16 +43,6 @@ class MobileProgram extends Component {
                 <div className={mobileNextChannel}><ChannelButton direction="next" to={this.props.nextChannelSlug} /></div>
               }
             </React.Fragment>
-          }
-        </MobileProgramContainer>
-        <MobileProgramContainer className={videoContainer}>
-          { this.props.currentProgramBlock &&
-            <Video
-              video={this.props.currentProgramBlock.currentVideo}
-              timestamp={this.props.currentProgramBlock.timestampToStartVideo}
-              className={mobileVideo}
-              isMobile={true}
-            />
           }
           { (!this.props.currentProgramBlock || !this.props.currentProgramBlock.fields.videos) &&
             <VideoPlaceholderWrapper className={mobileVideo} />
@@ -99,14 +95,10 @@ const MobileProgramContainer = styled('div')`
   transform-origin: 50vw;
   width: ${mobileViewportHeight};
   height: 100vw;
-  position: absolute;
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-`;
-
-const videoContainer = css`
-  z-index: -1; // Necessary because of the transform
 `;
 
 const mobileVideoWidth = '90vw * 1.33';

--- a/src/MobileProgram.js
+++ b/src/MobileProgram.js
@@ -12,6 +12,7 @@ import TVGuideLink from './TVGuideLink';
 
 import {
   Logo, backgroundColor, borderColor, VideoPlaceholderWrapper,
+  mobileViewportHeight,
 } from './styles';
 
 class MobileProgram extends Component {
@@ -89,18 +90,18 @@ class MobileProgram extends Component {
 }
 
 const MobileProgramContainer = styled('div')`
-  width: 100vh;
+  transform: rotate(90deg);
+  transform-origin: 50vw;
+  width: ${mobileViewportHeight};
   height: 100vw;
   position: relative;
   display: flex;
   align-items: center;
   justify-content: center;
-  transform: rotate(90deg);
-  transform-origin: 50vw;
 `;
 
 const mobileVideoWidth = '90vw * 1.33';
-const mobileTextHeight = `calc((100vh - (${mobileVideoWidth})) / 2 - 1rem)`;
+const mobileTextHeight = `calc((${mobileViewportHeight} - (${mobileVideoWidth})) / 2 - 1rem)`;
 const mobileInfoContainerHeight = `calc((${mobileVideoWidth}) + ${mobileTextHeight} + 1rem)`;
 
 const mobileVideo = css`

--- a/src/Program.js
+++ b/src/Program.js
@@ -116,7 +116,6 @@ class Program extends Component {
               <Video
                 video={currentProgramBlock.currentVideo}
                 timestamp={currentProgramBlock.timestampToStartVideo}
-                cropControls={true}
               />
               <VideoControls hasMultipleChannels={this.props.previousChannelSlug} maxMode={allowMaxMode && this.state.maxMode}>
                 { this.props.previousChannelSlug &&

--- a/src/Video.js
+++ b/src/Video.js
@@ -154,7 +154,11 @@ class Video extends Component {
       <React.Fragment>
         {this.props.video &&
           <React.Fragment>
-            <ReactPlayerWrapper className={this.props.className} cropControls={this.props.cropControls}>
+            <ReactPlayerWrapper
+              className={this.props.className}
+              cropControls={this.props.cropControls}
+              isMobile={this.props.isMobile}
+            >
               <VideoOverlay />
               <ReactPlayer
                 ref={this.ref}
@@ -219,9 +223,9 @@ class Video extends Component {
 
 const ReactPlayerWrapper = styled('div')`
   position: relative;
-  padding-top: 75%;
   background-color: ${videoBackgroundColor};
   ${props => props.cropControls && 'overflow: hidden;'}
+  padding-top: ${props => props.isMobile ? '50%' : '75%'};
 `;
 
 const reactPlayerStyle = css`
@@ -232,7 +236,6 @@ const reactPlayerStyle = css`
 
 const croppedReactPlayerStyle = css`
   position: absolute;
-  top: 0;
   left: 0;
   top: -20%;
 `;
@@ -251,7 +254,8 @@ const progressStyle = css`
 `;
 
 Video.defaultProps = {
-  timestamp: 0
+  timestamp: 0,
+  isMobile: false,
 }
 
 const mapStateToProps = state => ({

--- a/src/Video.js
+++ b/src/Video.js
@@ -156,7 +156,6 @@ class Video extends Component {
           <React.Fragment>
             <ReactPlayerWrapper
               className={this.props.className}
-              cropControls={this.props.cropControls}
               isMobile={this.props.isMobile}
             >
               <VideoOverlay />
@@ -173,8 +172,8 @@ class Video extends Component {
                 onDuration={this.onDuration}
                 onError={this.onError}
                 width="100%"
-                height={this.props.cropControls ? "140%" : "100%"}
-                className={this.props.cropControls ? croppedReactPlayerStyle : reactPlayerStyle}
+                height="140%"
+                className={croppedReactPlayerStyle}
                 config={{
                   youtube: {
                     playerVars: {
@@ -224,14 +223,8 @@ class Video extends Component {
 const ReactPlayerWrapper = styled('div')`
   position: relative;
   background-color: ${videoBackgroundColor};
-  ${props => props.cropControls && 'overflow: hidden;'}
+  overflow: hidden;
   padding-top: ${props => props.isMobile ? '50%' : '75%'};
-`;
-
-const reactPlayerStyle = css`
-  position: absolute;
-  top: 0;
-  left: 0;
 `;
 
 const croppedReactPlayerStyle = css`

--- a/src/styles.js
+++ b/src/styles.js
@@ -7,6 +7,8 @@ export const videoBackgroundColor = '#000';
 
 export const borderColor = '#4E475D';
 
+export const mobileViewportHeight = window.innerHeight + 'px';
+
 export const Logo = styled('div')`
   font-weight: 900;
   font-size: 13px;

--- a/src/styles.js
+++ b/src/styles.js
@@ -39,7 +39,7 @@ export const programBlockBase = `
 
 export const VideoPlaceholderWrapper = styled('div')`
   position: relative;
-  padding-top: 75%;
+  padding-top: ${props => props.isMobile ? '50%' : '75%'};
   background: url(./static_placeholder_simpler.gif);
   background-size: cover;
 `;


### PR DESCRIPTION
- Detect actual 'viewport height' on mobile to properly align elements
- Correctly ratio video size based on mobile vs desktop, including the placeholder image
- Make sure video controls/info are always cropped
- Add test mobile layout HTML example if at some point we need to experiment with another approach.